### PR TITLE
Add Circuit Python examples

### DIFF
--- a/Examples/CircuitPython/README.md
+++ b/Examples/CircuitPython/README.md
@@ -1,0 +1,14 @@
+##Ejemplos de codigo en CircuitPython
+
+###Todos los ejemplos estan optimizados para la tarjeta:
+
+##Bast Pro Mini M0.
+
++ blink.py
+>Enciende y apaga el Led incroporado en la tarjeta.
++ i2c_show.py
+> Muestra todos los pines que pueden ser usados para i2c
++ pinout_show.py
+>Muestra los pines disponibles en la tarjeta.
++ uart_show.py
+>Muestra todos los pines que pueden ser usados para UART.

--- a/Examples/CircuitPython/blink.py
+++ b/Examples/CircuitPython/blink.py
@@ -1,0 +1,13 @@
+# Escribe tu código aquí :-)
+import digitalio
+import board
+import time
+
+led = digitalio.DigitalInOut(board.LED)
+led.direction=digitalio.Direction.OUTPUT
+
+while True:
+    led.value = False
+    time.sleep(0.5)
+    led.value = True
+    time.sleep(0.5)

--- a/Examples/CircuitPython/i2c_show.py
+++ b/Examples/CircuitPython/i2c_show.py
@@ -1,0 +1,39 @@
+#Muestra los pines donde se puede crear
+#una instancia i2c
+import board
+import busio
+from microcontroller import Pin
+
+def is_hardware_I2C(scl, sda):
+    try:
+        p = busio.I2C(scl, sda)
+        p.deinit()
+        return True
+    except ValueError:
+        return False
+    except RuntimeError:
+        return True
+
+
+def get_unique_pins():
+    #exclude = ['NEOPIXEL', 'APA102_MOSI', 'APA102_SCK']
+    exclude = []
+    pins = [pin for pin in [
+        getattr(board, p) for p in dir(board) if p not in exclude]
+            if isinstance(pin, Pin)]
+    unique = []
+    for p in pins:
+        if p not in unique:
+            unique.append(p)
+    return unique
+
+
+for scl_pin in get_unique_pins():
+    for sda_pin in get_unique_pins():
+        if scl_pin is sda_pin:
+            continue
+        else:
+            if is_hardware_I2C(scl_pin, sda_pin):
+                print("SCL pin:", scl_pin, "\t SDA pin:", sda_pin)
+            else:
+                pass

--- a/Examples/CircuitPython/pinout_show.py
+++ b/Examples/CircuitPython/pinout_show.py
@@ -1,0 +1,5 @@
+#Muestra el PinOut de la Tarjeta
+import  board
+
+print(dir(board))
+

--- a/Examples/CircuitPython/uart_show.py
+++ b/Examples/CircuitPython/uart_show.py
@@ -1,0 +1,36 @@
+import board
+import busio
+from microcontroller import Pin
+
+
+def is_hardware_uart(tx, rx):
+    try:
+        p = busio.UART(tx, rx)
+        p.deinit()
+        return True
+    except ValueError:
+        return False
+
+
+def get_unique_pins():
+    #exclude = ['NEOPIXEL', 'APA102_MOSI', 'APA102_SCK']
+    exclude = []
+    pins = [pin for pin in [
+        getattr(board, p) for p in dir(board) if p not in exclude]
+            if isinstance(pin, Pin)]
+    unique = []
+    for p in pins:
+        if p not in unique:
+            unique.append(p)
+    return unique
+
+
+for tx_pin in get_unique_pins():
+    for rx_pin in get_unique_pins():
+        if rx_pin is tx_pin:
+            continue
+        else:
+            if is_hardware_uart(tx_pin, rx_pin):
+                print("RX pin:", rx_pin, "\t TX pin:", tx_pin)
+            else:
+                pass


### PR DESCRIPTION
Ejemplos de código en Circuit Python
Todos los ejemplos están optimizados para la tarjeta:
Bast Pro Mini M0.